### PR TITLE
Fix: Change 'Hint' to 'HINT' in time-bar.component.html

### DIFF
--- a/guessx.client/src/app/game-room/time-bar/time-bar.component.html
+++ b/guessx.client/src/app/game-room/time-bar/time-bar.component.html
@@ -8,7 +8,7 @@
 
     <div class="flex items-center text-sm text-gray-300">
       <!-- Hint -->
-      <div class="text-sm text-gaming-neon-pink">Hint {{ currentHint }} of {{ maxHints }}</div>
+      <div class="text-sm text-gaming-neon-pink">HINT {{ currentHint }} of {{ maxHints }}</div>
 
       <!-- Botón Skip -->
       <button


### PR DESCRIPTION
This pull request updates the `time-bar.component.html` file to change the word 'Hint' to 'HINT' for consistency and emphasis.